### PR TITLE
rt#130238: fix `'.' is no longer in @INC` error during Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -10,9 +10,9 @@ my $DEBUG = grep { m/^--debug$/ } @ARGV;
 my $can_compile = $^O =~ /win32|cygwin/i;
 
 warn "** This module can only work under Win32\n" unless $can_compile;
-	
+
 # generate Win32/GuiTest/Examples.pm
-do 'eg/make_eg.pl';
+do './eg/make_eg.pl';
 
 my @make = (
 	NAME				=> 'Win32::GuiTest',


### PR DESCRIPTION
perl 5.26.0 and onward no longer include '.' in @INC, so `do 'eg/make_eg.pl'` fails.

(fixes bug reported in https://rt.cpan.org/Ticket/Display.html?id=130238)