### PR TITLE
rt#130258: change SendMessage from `int` to `IV`

### DIFF
--- a/GuiTest.xs
+++ b/GuiTest.xs
@@ -1177,7 +1177,7 @@ GetChildDepth(hAncestor, hChild)
     OUTPUT:
         RETVAL
 
-int
+IV
 SendMessage(hwnd, msg, wParam, lParam)
   HWND hwnd
   UINT msg


### PR DESCRIPTION
https://rt.cpan.org/Ticket/Display.html?id=130258

SendMessage is defined as returning an `int`, but Microsoft defines it as being an `LRESULT` (https://docs.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-sendmessage).  In the 64bit application, the LRESULT would be 64-bit but the `int` is only 32-bit. 

by changing to `IV`, SendMessage will return the right size integer for Perl to be able to handle, whether perl is 32-bit or 64-bit.